### PR TITLE
Adds role based access control for routes

### DIFF
--- a/components/ConnectWallet.js
+++ b/components/ConnectWallet.js
@@ -1,11 +1,15 @@
 import { PeraWalletConnect } from '@perawallet/connect';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { isAuthenticated } from '../services/authService';
 
 const peraWallet = new PeraWalletConnect();
 
 export default function ConnectWallet() {
   const [accountAddress, setAccountAddress] = useState(null);
   const isConnectedToPeraWallet = !!accountAddress;
+  const router = useRouter();
+  const user = isAuthenticated();
 
   function handleConnectWalletClick() {
     peraWallet
@@ -14,6 +18,10 @@ export default function ConnectWallet() {
         peraWallet.connector.on('disconnect', handleDisconnectWalletClick);
 
         setAccountAddress(newAccounts[0]);
+        // TODO: Set User.walletAddress in database
+        user.walletAddress = newAccounts[0];
+        localStorage.setItem('user', JSON.stringify(user));
+        router.push('/onboarding');
       })
       .catch((error) => {
         if (error?.data?.type !== 'CONNECT_MODAL_CLOSED') {
@@ -26,6 +34,9 @@ export default function ConnectWallet() {
     peraWallet.disconnect();
 
     setAccountAddress(null);
+    // TODO: Remove localStorage
+    localStorage.clear();
+    router.push('/');
   }
 
   useEffect(() => {

--- a/pages/distributor/index.js
+++ b/pages/distributor/index.js
@@ -4,16 +4,17 @@ import { useRouter } from 'next/router';
 import { isAuthenticated } from '../../services/authService';
 import { USER_ROLES } from '../../constants';
 
-export default function Register() {
+export default function Dashboard() {
   const router = useRouter();
   const user = isAuthenticated();
-  const { walletAddress, role } = user;
+  const { walletAddress, role, company } = user;
   const { farmer, distributor } = USER_ROLES;
 
   useEffect(() => {
     if (!walletAddress) router.push('/');
     if (role === farmer) router.push('/farmer');
-  }, [distributor, farmer, role, router, walletAddress]);
+    if (!company) router.push('/distributor/register');
+  }, [distributor, farmer, company, role, router, walletAddress]);
 
   return (
     <Layout>
@@ -21,7 +22,7 @@ export default function Register() {
         <div className="flex flex-col my-6 space-y-3 p-8">
           <div className="mx-auto max-w-xl">
             <h1 className="text-2xl font-extrabold sm:text-4xl text-center">
-              Register Account
+              Distributor Dashboard
             </h1>
           </div>
         </div>

--- a/pages/farmer/index.js
+++ b/pages/farmer/index.js
@@ -4,16 +4,17 @@ import { useRouter } from 'next/router';
 import { isAuthenticated } from '../../services/authService';
 import { USER_ROLES } from '../../constants';
 
-export default function Register() {
+export default function Dashboard() {
   const router = useRouter();
   const user = isAuthenticated();
-  const { walletAddress, role } = user;
+  const { walletAddress, role, farms } = user;
   const { farmer, distributor } = USER_ROLES;
 
   useEffect(() => {
     if (!walletAddress) router.push('/');
-    if (role === farmer) router.push('/farmer');
-  }, [distributor, farmer, role, router, walletAddress]);
+    if (role === distributor) router.push('/distributor');
+    if (!farms) router.push('/farmer/register');
+  }, [distributor, farmer, role, farms, router, walletAddress]);
 
   return (
     <Layout>
@@ -21,7 +22,7 @@ export default function Register() {
         <div className="flex flex-col my-6 space-y-3 p-8">
           <div className="mx-auto max-w-xl">
             <h1 className="text-2xl font-extrabold sm:text-4xl text-center">
-              Register Account
+              Farmer Dashboard
             </h1>
           </div>
         </div>

--- a/pages/farmer/register.js
+++ b/pages/farmer/register.js
@@ -1,6 +1,20 @@
 import Layout from '../../components/Layout';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { isAuthenticated } from '../../services/authService';
+import { USER_ROLES } from '../../constants';
 
 export default function Register() {
+  const router = useRouter();
+  const user = isAuthenticated();
+  const { walletAddress, role } = user;
+  const { farmer, distributor } = USER_ROLES;
+
+  useEffect(() => {
+    if (!walletAddress) router.push('/');
+    if (role === distributor) router.push('/distributor');
+  }, [distributor, farmer, role, router, walletAddress]);
+
   return (
     <Layout>
       <div className="flex flex-col max-w-5xl px-2 mx-auto space-y-4">

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,22 @@
 import Hero from '../components/Hero';
 import Layout from '../components/Layout';
+import { isAuthenticated } from '../services/authService';
+import { useRouter } from 'next/router';
+import { USER_ROLES } from '../constants';
+import { useEffect } from 'react';
+const { farmer, distributor } = USER_ROLES;
 
 export default function Home() {
+  const router = useRouter();
+  const user = isAuthenticated();
+  const { role, walletAddress } = user;
+
+  useEffect(() => {
+    if (role === farmer) router.replace('/farmer');
+    if (role === distributor) router.replace('/distributor');
+    if (walletAddress && !role) router.replace('/onboarding');
+  }, [role, router, walletAddress]);
+
   return (
     <Layout>
       <Hero />

--- a/pages/onboarding.js
+++ b/pages/onboarding.js
@@ -1,14 +1,22 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Layout from '../components/Layout';
 import RadioButton from '../components/RadioButton';
-import { USER_ROLES } from '../constants';
 import { useRouter } from 'next/router';
+import { isAuthenticated } from '../services/authService';
+import { USER_ROLES } from '../constants';
 
 export default function Onboarding() {
   const [userRole, setUserRole] = useState(null);
   const router = useRouter();
-  const user = {};
+  const user = isAuthenticated();
+  const { walletAddress, role } = user;
   const { farmer, distributor } = USER_ROLES;
+
+  useEffect(() => {
+    if (!walletAddress) router.push('/');
+    if (role === farmer) router.push('/farmer/register');
+    if (role === distributor) router.push('/distributor/register');
+  }, [distributor, farmer, role, router, walletAddress]);
 
   const handleFarmerChange = () => setUserRole(farmer);
   const handleDistributorChange = () => setUserRole(distributor);
@@ -17,6 +25,7 @@ export default function Onboarding() {
     event.preventDefault();
 
     user.role = userRole;
+
     // TODO: Remove localStorage and set User.role in the database
     localStorage.setItem('user', JSON.stringify(user));
 

--- a/services/authService.js
+++ b/services/authService.js
@@ -1,0 +1,14 @@
+export const isAuthenticated = () => {
+  let user;
+
+  // TODO: Replace localStorage with database call to get user
+  if (typeof window !== 'undefined') {
+    user = localStorage.getItem('user');
+  }
+
+  if (!user) {
+    return {};
+  }
+
+  return JSON.parse(user);
+};


### PR DESCRIPTION
Closes #28.

Farmers should only be able to access the Farmer Dashboard (`/farmer`).

Distributors should only be able to access the Distributor Dashboard (`/distributor`).

If a user does not have a role they can only access onboarding (`/onboarding`).

If they select farmer they'll be redirected to register a farm (`/farmer/register`).

If they select distributor they'll be redirected to register their account (`/distributor/register`).